### PR TITLE
Support wildcard licenses – part 2

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -14,7 +14,7 @@ if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 } else {
     // load all the .env files
-    (new Dotenv(false))->loadEnv(dirname(__DIR__) . '/.env');
+    (new Dotenv(true))->loadEnv(dirname(__DIR__) . '/.env');
 }
 
 $_SERVER += $_ENV;

--- a/src/Components/Api/Client.php
+++ b/src/Components/Api/Client.php
@@ -4,7 +4,9 @@ namespace App\Components\Api;
 
 use App\Components\Api\Exceptions\AccessDeniedException;
 use App\Components\Api\Exceptions\TokenMissingException;
+use App\Struct\License\Binaries;
 use App\Struct\License\License;
+use App\Struct\License\VariantType;
 use App\Struct\Shop\Shop;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\HttpClient\Exception\ClientException;
@@ -73,7 +75,12 @@ class Client
     }
 
     /**
+     * @param AccessToken $token
      * @return Shop[]
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     public function shops(AccessToken $token): array
     {
@@ -123,22 +130,33 @@ class Client
     }
 
     /**
+     * @param AccessToken $token
      * @return License[]
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     public function licenses(AccessToken $token): array
     {
         $this->useToken($token);
 
-        if ($token->getShop()->type === 'partner') {
+        if ($token->getShop()->type === Shop::TYPE_PARTNER) {
             $content = $this->cachedRequest('GET', self::ENDPOINT . 'wildcardlicensesinstances/' . $token->getShop()->id);
 
             $licenses = [];
             foreach ($content->plugins as $pluginData) {
-                $license = new \stdClass();
+                $license = new License();
                 $license->archived = false;
                 $license->plugin = $pluginData;
-                $license->variantType = new \stdClass();
+                $license->variantType = new VariantType();
                 $license->variantType->name = 'buy'; // this is not really true but it's okay for our purposes
+
+                // for wildcard licenses there is only one available binary
+                // it is always the newest binary for the configured shopware version
+                $license->plugin->binaries = $this->getAvailableWildcardBinary($license);
 
                 $licenses[] = $license;
             }
@@ -177,23 +195,55 @@ class Client
         return $content;
     }
 
-    public function fetchDownloadLink(string $binaryLink): ?string
+    /**
+     * @param string $binaryLink
+     * @return array|null
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    public function fetchDownloadJson(string $binaryLink): ?array
     {
         if (!$this->currentToken) {
             throw new TokenMissingException();
         }
 
         try {
+            $query = ['json' => true];
+            $headers = [];
+            if ($this->currentToken->getShop()->type === Shop::TYPE_PARTNER) {
+                $headers = [
+                    'X-Shopware-Token' => $this->currentToken()->getToken(),
+                ];
+            } else {
+                $query['shopId'] = $this->currentToken->getShop()->id;
+            }
+
             $json = $this->client->request('GET', self::ENDPOINT . $binaryLink, [
-                'query' => [
-                    'json' => true,
-                    'shopId' => $this->currentToken->getShop()->id,
-                ],
+                'query' => $query,
+                'headers' => $headers,
             ])->toArray();
         } catch (ClientException $e) {
             return null;
         }
 
+        return $json;
+    }
+
+    /**
+     * @param string $binaryLink
+     * @return string|null
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    public function fetchDownloadLink(string $binaryLink): ?string
+    {
+        $json = $this->fetchDownloadJson($binaryLink);
         if (!array_key_exists('url', $json)) {
             return null;
         }
@@ -201,9 +251,45 @@ class Client
         return $json['url'];
     }
 
+    /**
+     * @param string $binaryLink
+     * @return string|null
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    public function fetchDownloadVersion(string $binaryLink): ?string
+    {
+        $json = $this->fetchDownloadJson($binaryLink);
+        if (!array_key_exists('binary', $json) || !is_array($json['binary'])) {
+            return null;
+        }
+
+        return $json['binary']['version'] ?? null;
+    }
+
     public function currentToken(): ?AccessToken
     {
         return $this->currentToken;
+    }
+
+    /**
+     * @param License $license
+     * @param Binaries|null $binary     Not neccassary for wildcard licenses
+     * @return string
+     */
+    public function getBinaryFilePath(License $license, Binaries $binary = null)
+    {
+        $shop = $this->currentToken->getShop();
+        if ($shop->type === Shop::TYPE_PARTNER) {
+            $filePath = "wildcardlicenses/{$shop->baseId}/instances/{$shop->id}/downloads/{$license->plugin->code}/{$shop->shopwareVersion->name}";
+        } else {
+            $filePath = 'plugins/' . $license->plugin->id . '/binaries/' . $binary->id . '/file';
+        }
+
+        return $filePath;
     }
 
     private function getLicensesListPath(AccessToken $token): string
@@ -224,6 +310,36 @@ class Client
         return 'partners/' . $token->getUserId() . '/customers/' . $token->getShop()->ownerId . '/shops/' . $token->getShop()->id . '/pluginlicenses/' . $licenseId;
     }
 
+    /**
+     * @param License $license
+     * @return array
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    private function getAvailableWildcardBinary(License $license): array
+    {
+        $version = $this->fetchDownloadVersion($this->getBinaryFilePath($license));
+
+        $binary = new Binaries();
+        $binary->version = $version;
+
+        return [$binary];
+    }
+
+    /**
+     * @param string $method
+     * @param string $uri
+     * @param array $options
+     * @return mixed
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
     private function cachedRequest(string $method, string $uri, array $options = [])
     {
         $cacheKey = md5(json_encode($this->currentToken) . $method . $uri . json_encode($options));

--- a/src/Components/Api/Client.php
+++ b/src/Components/Api/Client.php
@@ -104,7 +104,7 @@ class Client
             $content = $this->client->request('GET', self::ENDPOINT . 'wildcardlicenses?companyId=' . $token->getUserId() . '&type=partner')->getContent();
             $content = json_decode($content);
             $content = array_shift($content);
-            $instances = $content->instances;
+            $instances = $content->instances ?? [];
 
             $wildcardShops = Shop::mapList($instances);
             foreach ($wildcardShops as $shop) {
@@ -280,7 +280,7 @@ class Client
      * @param Binaries|null $binary     Not neccassary for wildcard licenses
      * @return string
      */
-    public function getBinaryFilePath(License $license, Binaries $binary = null)
+    public function getBinaryFilePath($license, $binary = null)
     {
         $shop = $this->currentToken->getShop();
         if ($shop->type === Shop::TYPE_PARTNER) {

--- a/src/Components/Api/Client.php
+++ b/src/Components/Api/Client.php
@@ -77,10 +77,6 @@ class Client
     /**
      * @param AccessToken $token
      * @return Shop[]
-     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     public function shops(AccessToken $token): array
     {
@@ -132,12 +128,6 @@ class Client
     /**
      * @param AccessToken $token
      * @return License[]
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     public function licenses(AccessToken $token): array
     {
@@ -198,11 +188,6 @@ class Client
     /**
      * @param string $binaryLink
      * @return array|null
-     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     public function fetchDownloadJson(string $binaryLink): ?array
     {
@@ -235,11 +220,6 @@ class Client
     /**
      * @param string $binaryLink
      * @return string|null
-     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     public function fetchDownloadLink(string $binaryLink): ?string
     {
@@ -254,11 +234,6 @@ class Client
     /**
      * @param string $binaryLink
      * @return string|null
-     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     public function fetchDownloadVersion(string $binaryLink): ?string
     {
@@ -313,11 +288,6 @@ class Client
     /**
      * @param License $license
      * @return array
-     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     private function getAvailableWildcardBinary(License $license): array
     {
@@ -334,11 +304,6 @@ class Client
      * @param string $uri
      * @param array $options
      * @return mixed
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
-     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     private function cachedRequest(string $method, string $uri, array $options = [])
     {

--- a/src/Components/PackagistLoader.php
+++ b/src/Components/PackagistLoader.php
@@ -130,7 +130,9 @@ class PackagistLoader
             $isOldArchiveStructure = in_array($version['type'], ['shopware-core-plugin', 'shopware-backend-plugin', 'shopware-frontend-plugin']);
             $version['name'] = $packageName;
             $version['dist'] = [
-                'url' => $this->generateLink('plugins/' . $license->plugin->id . '/binaries/' . $binary->id . '/file', $this->client->currentToken(), $isOldArchiveStructure),
+                'url' => $this->generateLink(
+                    $this->client->getBinaryFilePath($license, $binary), $this->client->currentToken(), $isOldArchiveStructure
+                ),
                 'type' => 'zip',
             ];
 

--- a/src/Components/PackagistLoader.php
+++ b/src/Components/PackagistLoader.php
@@ -37,7 +37,8 @@ class PackagistLoader
 
     /**
      * @param License[] $licenses
-     * @param Shop      $shop
+     * @param Shop $shop
+     * @return array
      */
     public function load(array $licenses, object $shop): array
     {
@@ -48,7 +49,8 @@ class PackagistLoader
 
     /**
      * @param License[] $licenses
-     * @param Shop      $shop
+     * @param Shop $shop
+     * @return array
      */
     private function mapLicensesToComposerPackages(array $licenses, object $shop): array
     {
@@ -88,7 +90,8 @@ class PackagistLoader
 
     /**
      * @param License $license
-     * @param Shop    $shop
+     * @param Shop $shop
+     * @return array
      */
     private function convertBinaries(string $packageName, $license, Package $package, object $shop): array
     {

--- a/src/Struct/Shop/Shop.php
+++ b/src/Struct/Shop/Shop.php
@@ -4,6 +4,9 @@ namespace App\Struct\Shop;
 
 class Shop extends \App\Struct\Struct
 {
+
+    const TYPE_PARTNER = 'partner';
+
     /** @var int */
     public $id;
 
@@ -72,6 +75,9 @@ class Shop extends \App\Struct\Struct
 
     /** @var string */
     public $type;
+
+    /** @var int */
+    public $baseId;
 
     public static $mappedFields = [
         'subscriptionModules' => 'App\Struct\Shop\SubscriptionModules',

--- a/symfony.lock
+++ b/symfony.lock
@@ -126,6 +126,12 @@
     "jean85/pretty-package-versions": {
         "version": "1.2"
     },
+    "laminas/laminas-code": {
+        "version": "3.4.1"
+    },
+    "laminas/laminas-eventmanager": {
+        "version": "3.2.1"
+    },
     "laminas/laminas-zendframework-bridge": {
         "version": "1.0.1"
     },


### PR DESCRIPTION
With this commit, support for downloading and requiring wildcard licensed packages via composer.

Additionally, I changed the argument `usePutenv` in the Dotenv constructor in `bootstrap.php` because environment variables are always `null` using `getenv()` in my environment. I have found no other solution.